### PR TITLE
feat: add bot players to fill spots in incomplete matches

### DIFF
--- a/drizzle/0006_add_is_bot.sql
+++ b/drizzle/0006_add_is_bot.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "users" ADD COLUMN "is_bot" boolean DEFAULT false NOT NULL;
+
+-- Insert pre-created bot users
+INSERT INTO "users" ("id", "email", "name", "nickname", "is_admin", "is_whitelisted", "is_bot", "created_at", "updated_at")
+VALUES
+  ('bot_frn', 'frn_bot@bot.local', 'frn_bot', 'frn_bot', false, false, true, NOW(), NOW()),
+  ('bot_johnathan', 'bot_johnathan@bot.local', 'bot johnathan', 'bot johnathan', false, false, true, NOW(), NOW())
+ON CONFLICT ("id") DO NOTHING;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1761509407201,
       "tag": "0005_stiff_warbound",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1762000000000,
+      "tag": "0006_add_is_bot",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/admin/seed-bots/route.ts
+++ b/src/app/api/admin/seed-bots/route.ts
@@ -1,0 +1,55 @@
+import { NextResponse } from 'next/server';
+import { auth } from '@clerk/nextjs/server';
+import { DatabaseService } from '@/lib/db/service';
+
+const BOT_USERS = [
+  {
+    id: 'bot_frn',
+    email: 'frn_bot@bot.local',
+    name: 'frn_bot',
+    nickname: 'frn_bot',
+    isAdmin: false,
+    isWhitelisted: false,
+    isBot: true,
+  },
+  {
+    id: 'bot_johnathan',
+    email: 'bot_johnathan@bot.local',
+    name: 'bot johnathan',
+    nickname: 'bot johnathan',
+    isAdmin: false,
+    isWhitelisted: false,
+    isBot: true,
+  },
+];
+
+export async function POST() {
+  try {
+    const { userId } = await auth();
+    if (!userId) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const user = await DatabaseService.getUserById(userId);
+    if (!user?.isAdmin) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 });
+    }
+
+    const results: { name: string; status: string }[] = [];
+
+    for (const bot of BOT_USERS) {
+      const existing = await DatabaseService.getUserById(bot.id);
+      if (existing) {
+        results.push({ name: bot.name, status: 'already exists' });
+      } else {
+        await DatabaseService.addUser({ ...bot, createdAt: new Date() });
+        results.push({ name: bot.name, status: 'created' });
+      }
+    }
+
+    return NextResponse.json({ success: true, bots: results });
+  } catch (error) {
+    console.error('Error seeding bots:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/games/[id]/mvp/non-voters/route.ts
+++ b/src/app/api/games/[id]/mvp/non-voters/route.ts
@@ -76,28 +76,31 @@ export async function GET(
 
     const votedUserIds = votedUsers.map(v => v.voterId);
 
-    // Find participants who haven't voted
+    // Find participants who haven't voted (exclude bots — they never vote)
     const nonVoterIds = participants.filter(participantId => !votedUserIds.includes(participantId));
 
-    // Get user details for non-voters
-    const nonVoters = nonVoterIds.length > 0 
+    // Get user details for non-voters, excluding bots
+    const nonVoters = nonVoterIds.length > 0
       ? await db
           .select({
             id: users.id,
             name: users.name,
             nickname: users.nickname,
-            imageUrl: users.imageUrl
+            imageUrl: users.imageUrl,
+            isBot: users.isBot,
           })
           .from(users)
           .where(inArray(users.id, nonVoterIds))
       : [];
 
+    const realNonVoters = nonVoters.filter(u => !u.isBot);
+
     return NextResponse.json({
       gameId,
       totalParticipants: participants.length,
       votersCount: votedUserIds.length,
-      nonVotersCount: nonVoterIds.length,
-      nonVoters: nonVoters.map(user => ({
+      nonVotersCount: realNonVoters.length,
+      nonVoters: realNonVoters.map(user => ({
         id: user.id,
         name: user.name,
         nickname: user.nickname,

--- a/src/app/api/games/[id]/mvp/results/route.ts
+++ b/src/app/api/games/[id]/mvp/results/route.ts
@@ -96,26 +96,29 @@ export async function GET(
 
       const votedUserIds = votedUsers.map(v => v.voterId);
 
-      // Find participants who haven't voted
+      // Find participants who haven't voted (bots never vote, exclude them)
       const nonVoterIds = gameData.participants.filter(participantId => !votedUserIds.includes(participantId));
 
-      // Get user details for non-voters
-      const nonVoters = nonVoterIds.length > 0 
+      // Get user details for non-voters, excluding bots
+      const nonVoters = nonVoterIds.length > 0
         ? await db
             .select({
               id: users.id,
               name: users.name,
               nickname: users.nickname,
-              imageUrl: users.imageUrl
+              imageUrl: users.imageUrl,
+              isBot: users.isBot,
             })
             .from(users)
             .where(inArray(users.id, nonVoterIds))
         : [];
 
+      const realNonVoters = nonVoters.filter(u => !u.isBot);
+
       nonVotersInfo = {
         votersCount: votedUserIds.length,
-        nonVotersCount: nonVoterIds.length,
-        nonVoters: nonVoters.map(user => ({
+        nonVotersCount: realNonVoters.length,
+        nonVoters: realNonVoters.map(user => ({
           id: user.id,
           name: user.name,
           nickname: user.nickname || undefined,

--- a/src/app/api/games/[id]/mvp/vote/route.ts
+++ b/src/app/api/games/[id]/mvp/vote/route.ts
@@ -68,7 +68,7 @@ export async function POST(
       }, { status: 400 });
     }
 
-    // Verify the voted-for user exists
+    // Verify the voted-for user exists and is not a bot
     const votedForUser = await db
       .select()
       .from(users)
@@ -77,6 +77,10 @@ export async function POST(
 
     if (!votedForUser.length) {
       return NextResponse.json({ error: 'Voted user not found' }, { status: 404 });
+    }
+
+    if (votedForUser[0].isBot) {
+      return NextResponse.json({ error: 'Cannot vote for bot players' }, { status: 400 });
     }
 
     // First, let's try inserting just the MVP vote to isolate the issue

--- a/src/app/api/webhooks/clerk/route.ts
+++ b/src/app/api/webhooks/clerk/route.ts
@@ -61,6 +61,7 @@ export async function POST(req: NextRequest) {
           imageUrl: clerkUser.image_url || undefined,
           isAdmin: false,
           isWhitelisted: true,
+          isBot: false,
         };
 
         await DatabaseService.addUser(newUser);

--- a/src/app/dashboard/history/page.tsx
+++ b/src/app/dashboard/history/page.tsx
@@ -470,7 +470,8 @@ export default function HistoryPage() {
                     nickname: player?.nickname,
                     imageUrl: player?.imageUrl,
                     votedAt: new Date(),
-                    position: index + 1
+                    position: index + 1,
+                    isBot: player?.isBot ?? false,
                   };
                 });
 

--- a/src/app/dashboard/rankings/page.tsx
+++ b/src/app/dashboard/rankings/page.tsx
@@ -160,7 +160,7 @@ export default function RankingsPage() {
 
       [...team1, ...team2].forEach(playerId => {
         const player = users.find(u => u.id === playerId);
-        if (!stats[playerId] && player) {
+        if (!stats[playerId] && player && !player.isBot) {
           // Count MVP votes for this player from games in the selected quarter
           const votesForPlayer = quarterMvpVotes.filter(vote => vote.votedForId === playerId).length;
 
@@ -738,9 +738,9 @@ export default function RankingsPage() {
         // Calcular ausencias para cada jugador activo
         const playerAbsences: Record<string, { player: User; attended: number; totalGames: number; absences: number }> = {};
 
-        // Inicializar todos los jugadores activos (whitelisted, no admin)
+        // Inicializar todos los jugadores activos (whitelisted, no admin, no bot)
         users.forEach(user => {
-          if (user.isWhitelisted && !user.isAdmin) {
+          if (user.isWhitelisted && !user.isAdmin && !user.isBot) {
             playerAbsences[user.id] = {
               player: user,
               attended: 0,

--- a/src/components/games/EditGameModal.tsx
+++ b/src/components/games/EditGameModal.tsx
@@ -92,11 +92,26 @@ export function EditGameModal({ game, users, onSave, onClose, currentUserId, noV
   // Player management functions
   const availableUsers = users.filter(user =>
     user.isWhitelisted &&
+    !user.isBot &&
     !participants.includes(user.id) &&
     !waitlist.includes(user.id)
   );
 
+  const availableBots = users.filter(user =>
+    user.isBot &&
+    !participants.includes(user.id) &&
+    !waitlist.includes(user.id)
+  );
+
+  const realParticipantCount = participants.filter(id => {
+    const u = users.find(u => u.id === id);
+    return u && !u.isBot;
+  }).length;
+
   const moveToParticipants = (userId: string, fromWaitlist = false) => {
+    const isBot = users.find(u => u.id === userId)?.isBot ?? false;
+    // Real players capped at 10; bots can fill spots beyond real players up to 10 total
+    if (!isBot && realParticipantCount >= 10) return;
     if (participants.length >= 10) return;
 
     setParticipants(prev => [...prev, userId]);
@@ -169,8 +184,8 @@ export function EditGameModal({ game, users, onSave, onClose, currentUserId, noV
               }`}
             >
               <Users className="h-4 w-4" />
-              <span className="hidden sm:inline">Jugadores ({participants.length}/10)</span>
-              <span className="sm:hidden">Jugad. ({participants.length}/10)</span>
+              <span className="hidden sm:inline">Jugadores ({realParticipantCount}/10)</span>
+              <span className="sm:hidden">Jugad. ({realParticipantCount}/10)</span>
             </button>
             <button
               onClick={() => setActiveTab('teams')}
@@ -326,7 +341,7 @@ export function EditGameModal({ game, users, onSave, onClose, currentUserId, noV
                   theme === 'dark' ? 'text-green-300' : 'text-green-800'
                 }`}>
                   <Users className="h-5 w-5" />
-                  Participantes ({participants.length}/10)
+                  Participantes ({realParticipantCount}/10{participants.length > realParticipantCount ? ` + ${participants.length - realParticipantCount} bot` : ''})
                 </h3>
 
                 <div className="space-y-2 min-h-[300px]">
@@ -336,7 +351,9 @@ export function EditGameModal({ game, users, onSave, onClose, currentUserId, noV
 
                     return (
                       <div key={userId} className={`flex items-center justify-between p-2 rounded ${
-                        theme === 'dark' ? 'bg-green-900/20' : 'bg-green-100/50'
+                        user.isBot
+                          ? theme === 'dark' ? 'bg-purple-900/20' : 'bg-purple-100/50'
+                          : theme === 'dark' ? 'bg-green-900/20' : 'bg-green-100/50'
                       }`}>
                         <div className="flex items-center gap-2">
                           <span className={`text-xs px-2 py-1 rounded ${
@@ -347,9 +364,20 @@ export function EditGameModal({ game, users, onSave, onClose, currentUserId, noV
                           {user.imageUrl && (
                             <img src={user.imageUrl} alt={user.name} className="w-8 h-8 rounded-full" />
                           )}
-                          <span className={`text-sm ${theme === 'dark' ? 'text-green-300' : 'text-green-700'}`}>
+                          <span className={`text-sm ${
+                            user.isBot
+                              ? theme === 'dark' ? 'text-purple-300' : 'text-purple-700'
+                              : theme === 'dark' ? 'text-green-300' : 'text-green-700'
+                          }`}>
                             {user.nickname || user.name}
                           </span>
+                          {user.isBot && (
+                            <span className={`text-xs px-1.5 py-0.5 rounded font-mono font-bold ${
+                              theme === 'dark' ? 'bg-purple-800/60 text-purple-200' : 'bg-purple-200 text-purple-800'
+                            }`}>
+                              BOT
+                            </span>
+                          )}
                         </div>
                         <div className="flex gap-1">
                           <button
@@ -477,7 +505,7 @@ export function EditGameModal({ game, users, onSave, onClose, currentUserId, noV
                   Disponibles ({availableUsers.length})
                 </h3>
 
-                <div className="space-y-2 min-h-[300px]">
+                <div className="space-y-2 min-h-[200px]">
                   {availableUsers.map(user => (
                     <div key={user.id} className={`flex items-center justify-between p-2 rounded ${
                       theme === 'dark' ? 'bg-slate-900/20' : 'bg-slate-100/50'
@@ -491,7 +519,7 @@ export function EditGameModal({ game, users, onSave, onClose, currentUserId, noV
                         </span>
                       </div>
                       <div className="flex gap-1">
-                        {participants.length < 10 && (
+                        {realParticipantCount < 10 && participants.length < 10 && (
                           <button
                             onClick={() => moveToParticipants(user.id)}
                             className={`px-2 py-1 rounded text-xs ${
@@ -520,13 +548,57 @@ export function EditGameModal({ game, users, onSave, onClose, currentUserId, noV
                   ))}
 
                   {availableUsers.length === 0 && (
-                    <div className={`text-center py-8 text-sm ${
+                    <div className={`text-center py-4 text-sm ${
                       theme === 'dark' ? 'text-slate-400' : 'text-slate-600'
                     }`}>
                       No hay usuarios disponibles
                     </div>
                   )}
                 </div>
+
+                {/* Bots section */}
+                {availableBots.length > 0 && (
+                  <>
+                    <h4 className={`font-semibold mt-4 mb-2 flex items-center gap-2 text-sm ${
+                      theme === 'dark' ? 'text-purple-300' : 'text-purple-800'
+                    }`}>
+                      🤖 Bots disponibles
+                    </h4>
+                    <div className="space-y-2">
+                      {availableBots.map(bot => (
+                        <div key={bot.id} className={`flex items-center justify-between p-2 rounded ${
+                          theme === 'dark' ? 'bg-purple-900/20' : 'bg-purple-50'
+                        }`}>
+                          <div className="flex items-center gap-2">
+                            <span className={`text-sm font-mono ${
+                              theme === 'dark' ? 'text-purple-300' : 'text-purple-700'
+                            }`}>
+                              {bot.name}
+                            </span>
+                            <span className={`text-xs px-1.5 py-0.5 rounded font-bold ${
+                              theme === 'dark' ? 'bg-purple-800/60 text-purple-200' : 'bg-purple-200 text-purple-800'
+                            }`}>
+                              BOT
+                            </span>
+                          </div>
+                          {participants.length < 10 && (
+                            <button
+                              onClick={() => moveToParticipants(bot.id)}
+                              className={`px-2 py-1 rounded text-xs ${
+                                theme === 'dark'
+                                  ? 'bg-purple-600 text-white hover:bg-purple-700'
+                                  : 'bg-purple-500 text-white hover:bg-purple-600'
+                              }`}
+                              title="Agregar bot como participante"
+                            >
+                              +Bot
+                            </button>
+                          )}
+                        </div>
+                      ))}
+                    </div>
+                  </>
+                )}
               </div>
             </div>
           )}

--- a/src/components/games/SundayCard.tsx
+++ b/src/components/games/SundayCard.tsx
@@ -12,6 +12,7 @@ interface VoterInfo {
   imageUrl?: string;
   votedAt: Date;
   position: number;
+  isBot?: boolean;
 }
 
 interface UserInfo {
@@ -385,8 +386,12 @@ export function SundayCard({
                     {game.teams.team1.map((playerId, index) => {
                       const player = voters.find(v => v.userId === playerId);
                       return (
-                        <div key={playerId} className={`text-xs px-2 py-1 rounded ${
-                          playerId === currentUserId
+                        <div key={playerId} className={`text-xs px-2 py-1 rounded flex items-center gap-1 ${
+                          player?.isBot
+                            ? theme === 'dark'
+                              ? 'bg-purple-900/40 text-purple-300'
+                              : 'bg-purple-100 text-purple-700'
+                            : playerId === currentUserId
                             ? theme === 'dark'
                               ? 'bg-blue-900/60 text-blue-200 font-semibold'
                               : 'bg-blue-200 text-blue-900 font-semibold'
@@ -395,6 +400,7 @@ export function SundayCard({
                               : 'bg-slate-100 text-slate-700'
                         }`}>
                           {player?.nickname || player?.name || `Jugador ${index + 1}`}
+                          {player?.isBot && <span className="font-bold font-mono text-[10px] opacity-70">BOT</span>}
                         </div>
                       );
                     })}
@@ -411,8 +417,12 @@ export function SundayCard({
                     {game.teams.team2.map((playerId, index) => {
                       const player = voters.find(v => v.userId === playerId);
                       return (
-                        <div key={playerId} className={`text-xs px-2 py-1 rounded ${
-                          playerId === currentUserId
+                        <div key={playerId} className={`text-xs px-2 py-1 rounded flex items-center gap-1 ${
+                          player?.isBot
+                            ? theme === 'dark'
+                              ? 'bg-purple-900/40 text-purple-300'
+                              : 'bg-purple-100 text-purple-700'
+                            : playerId === currentUserId
                             ? theme === 'dark'
                               ? 'bg-red-900/60 text-red-200 font-semibold'
                               : 'bg-red-200 text-red-900 font-semibold'
@@ -421,6 +431,7 @@ export function SundayCard({
                               : 'bg-slate-100 text-slate-700'
                         }`}>
                           {player?.nickname || player?.name || `Jugador ${index + 1}`}
+                          {player?.isBot && <span className="font-bold font-mono text-[10px] opacity-70">BOT</span>}
                         </div>
                       );
                     })}
@@ -647,7 +658,7 @@ export function SundayCard({
                       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                         {game.participants
                           .map(participantId => voters.find(v => v.userId === participantId))
-                          .filter(Boolean)
+                          .filter((player): player is VoterInfo => Boolean(player) && !player!.isBot)
                           .map(player => (
                             <button
                               key={player!.userId}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -8,6 +8,7 @@ export const users = pgTable('users', {
   imageUrl: text('image_url'),
   isAdmin: boolean('is_admin').default(false).notNull(),
   isWhitelisted: boolean('is_whitelisted').default(true).notNull(),
+  isBot: boolean('is_bot').default(false).notNull(),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 });

--- a/src/lib/db/service.ts
+++ b/src/lib/db/service.ts
@@ -25,6 +25,19 @@ export class DatabaseService {
       ...user,
       nickname: user.nickname ?? undefined,
       imageUrl: user.imageUrl ?? undefined,
+      isBot: user.isBot ?? false,
+      updatedAt: user.updatedAt ? new Date(user.updatedAt) : undefined,
+      createdAt: new Date(user.createdAt),
+    }));
+  }
+
+  static async getBotUsers(): Promise<User[]> {
+    const result = await db.select().from(users).where(eq(users.isBot, true));
+    return result.map(user => ({
+      ...user,
+      nickname: user.nickname ?? undefined,
+      imageUrl: user.imageUrl ?? undefined,
+      isBot: true,
       updatedAt: user.updatedAt ? new Date(user.updatedAt) : undefined,
       createdAt: new Date(user.createdAt),
     }));
@@ -33,11 +46,12 @@ export class DatabaseService {
   static async getUserById(id: string): Promise<User | undefined> {
     const result = await db.select().from(users).where(eq(users.id, id)).limit(1);
     if (result.length === 0) return undefined;
-    
+
     return {
       ...result[0],
       nickname: result[0].nickname ?? undefined,
       imageUrl: result[0].imageUrl ?? undefined,
+      isBot: result[0].isBot ?? false,
       updatedAt: result[0].updatedAt ? new Date(result[0].updatedAt) : undefined,
       createdAt: new Date(result[0].createdAt),
     };
@@ -52,6 +66,7 @@ export class DatabaseService {
       imageUrl: user.imageUrl || null,
       isAdmin: user.isAdmin,
       isWhitelisted: user.isWhitelisted,
+      isBot: user.isBot ?? false,
       createdAt: user.createdAt || new Date(),
       updatedAt: new Date(),
     });
@@ -59,14 +74,15 @@ export class DatabaseService {
 
   static async updateUser(updatedUser: User): Promise<void> {
     await db.update(users)
-      .set({ 
+      .set({
         email: updatedUser.email,
         name: updatedUser.name,
         nickname: updatedUser.nickname || null,
         imageUrl: updatedUser.imageUrl || null,
         isAdmin: updatedUser.isAdmin,
         isWhitelisted: updatedUser.isWhitelisted,
-        updatedAt: new Date() 
+        isBot: updatedUser.isBot ?? false,
+        updatedAt: new Date()
       })
       .where(eq(users.id, updatedUser.id));
   }
@@ -124,12 +140,13 @@ export class DatabaseService {
   static async getWhitelistedUsers(): Promise<User[]> {
     const result = await db.select()
       .from(users)
-      .where(and(eq(users.isWhitelisted, true), eq(users.isAdmin, false)));
-    
+      .where(and(eq(users.isWhitelisted, true), eq(users.isAdmin, false), eq(users.isBot, false)));
+
     return result.map(user => ({
       ...user,
       nickname: user.nickname ?? undefined,
       imageUrl: user.imageUrl ?? undefined,
+      isBot: false,
       updatedAt: user.updatedAt ? new Date(user.updatedAt) : undefined,
       createdAt: new Date(user.createdAt),
     }));
@@ -824,15 +841,16 @@ export class DatabaseService {
       
       const allGames = await this.getAllGames();
       const allUsers = await this.getUsers();
-      const whitelistedUserIds = new Set(allUsers.filter(u => u.isWhitelisted).map(u => u.id));
-      
+      // Keep bots (isBot) even if not whitelisted
+      const allowedUserIds = new Set(allUsers.filter(u => u.isWhitelisted || u.isBot).map(u => u.id));
+
       let updatedCount = 0;
       const details: string[] = [];
-      
+
       for (const game of allGames) {
         const originalParticipantCount = game.participants.length;
-        const cleanedParticipants = game.participants.filter(participantId => 
-          whitelistedUserIds.has(participantId)
+        const cleanedParticipants = game.participants.filter(participantId =>
+          allowedUserIds.has(participantId)
         );
         
         if (cleanedParticipants.length !== originalParticipantCount) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -64,14 +64,15 @@ export function getNextAvailableMonth(): { month: number; year: number } {
 }
 
 export function generateTeams(players: string[]): { team1: string[]; team2: string[] } {
-  if (players.length !== 10) {
-    throw new Error('Exactly 10 players are required to form teams');
+  if (players.length < 2 || players.length % 2 !== 0) {
+    throw new Error('An even number of at least 2 players is required to form teams');
   }
-  
+
+  const half = players.length / 2;
   const shuffled = [...players].sort(() => Math.random() - 0.5);
   return {
-    team1: shuffled.slice(0, 5),
-    team2: shuffled.slice(5, 10),
+    team1: shuffled.slice(0, half),
+    team2: shuffled.slice(half),
   };
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,6 +6,7 @@ export interface User {
   imageUrl?: string;
   isAdmin: boolean;
   isWhitelisted: boolean; // For counting towards matches (excludes test users)
+  isBot: boolean; // Bot players that fill spots but are excluded from stats
   createdAt: Date;
   updatedAt?: Date;
 }


### PR DESCRIPTION
- Add `isBot` column to users schema and User type
- Create migration 0006 with bot column + seed frn_bot and bot johnathan
- Add POST /api/admin/seed-bots endpoint to insert bots via UI
- Exclude bots from whitelisted users count (don't affect 10-player threshold)
- Exclude bots from rankings, Hall of Shame, and MVP voting candidates
- Bots can't receive MVP votes (API-level validation)
- Bots excluded from non-voters tracking in MVP results
- EditGameModal: bots appear in a separate section with BOT badge, bypass real-player cap
- SundayCard: bots shown with BOT badge in team lists, excluded from MVP vote UI
- generateTeams: accept any even number >= 2 (supports mixed real+bot squads)
- cleanUpGames: preserve bot participants alongside whitelisted users

Close issue #10 